### PR TITLE
adapt theme for modsim website

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,5 +1,5 @@
 [theme]
-base="dark"
+base="light"
 primaryColor="#36d2ef"
 
 [runner]


### PR DESCRIPTION
@joergbrech, can we change the theme to the light theme to match the website?
see https://github.com/hbrs-cse/Modellbildung-und-Simulation/pull/450